### PR TITLE
Enable dependency link processing

### DIFF
--- a/deployment/roles/hub-backend/tasks/main.yml
+++ b/deployment/roles/hub-backend/tasks/main.yml
@@ -92,7 +92,7 @@
   pip:
     virtualenv: "{{backend_deploy_location}}/venv/"
     requirements: "{{backend_deploy_location}}/requirements.txt"
-    extra_args: "--pre --upgrade -i {{devpi_index_url}}"
+    extra_args: "--process-dependency-links --pre --upgrade -i {{devpi_index_url}}"
   become: yes
   notify: restart senic_hub
   tags: update_backend


### PR DESCRIPTION
One of the latest PRs introduced a dependency that's listed in `dependency_links` which is not taken into account by pip due to security implications. This fixes the issue temporarily...

Error for reference:

```
TASK: [hub-backend | install application] *************************************
failed: [plain-pi3martins] => {"cmd": "/srv/senic_hub/venv//bin/pip install --pre --upgrade -i https://pypi.senic.com/getsenic/master/+simple/ -r /srv/senic_hub/requirements.txt", "failed": true}
msg: stdout: Collecting asn1crypto==0.22.0 (from -r /srv/senic_hub/requirements.txt (line 1))
  Downloading https://pypi.senic.com/root/pypi/+f/5f8/356d63fb71516/asn1crypto-0.22.0-py2.py3-none-any.whl (97kB)
Requirement already up-to-date: cffi==1.8.3 in /usr/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 2))
Collecting click==6.6 (from -r /srv/senic_hub/requirements.txt (line 3))
  Downloading https://pypi.senic.com/root/pypi/+f/ded/5bf44698fd7de/click-6.6-py2.py3-none-any.whl (71kB)
Collecting colander==1.3.1 (from -r /srv/senic_hub/requirements.txt (line 4))
  Downloading https://pypi.senic.com/root/pypi/+f/439/2894a8607c1fe/colander-1.3.1-py2.py3-none-any.whl (118kB)
Requirement already up-to-date: cornice==1.2.1 in /srv/senic_hub/venv/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 5))
Requirement already up-to-date: cryptoyaml==0.2.0 in /srv/senic_hub/venv/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 6))
Requirement already up-to-date: cryptography==1.4 in /usr/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 7))
Requirement already up-to-date: idna==2.5 in /srv/senic_hub/venv/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 8))
Requirement already up-to-date: iso8601==0.1.11 in /srv/senic_hub/venv/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 9))
Requirement already up-to-date: PasteDeploy==1.5.2 in /srv/senic_hub/venv/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 10))
Requirement already up-to-date: netifaces==0.10.4 in /usr/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 11))
Collecting pyramid==1.7.3 (from -r /srv/senic_hub/requirements.txt (line 12))
  Downloading https://pypi.senic.com/root/pypi/+f/5cd/2740e253d2dab/pyramid-1.7.3-py2.py3-none-any.whl (575kB)
Collecting pytz==2016.10 (from -r /srv/senic_hub/requirements.txt (line 13))
  Downloading https://pypi.senic.com/root/pypi/+f/f3a/8520c1230f1e6/pytz-2016.10-py2.py3-none-any.whl (483kB)
Requirement already up-to-date: repoze.lru==0.6 in /srv/senic_hub/venv/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 14))
Collecting requests==2.12.4 (from -r /srv/senic_hub/requirements.txt (line 15))
  Downloading https://pypi.senic.com/root/pypi/+f/398/9eaeaa2ccad20/requests-2.12.4-py2.py3-none-any.whl (576kB)
Requirement already up-to-date: simplejson==3.10.0 in /srv/senic_hub/venv/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 16))
Requirement already up-to-date: translationstring==1.3 in /srv/senic_hub/venv/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 17))
Collecting venusian==1.0 (from -r /srv/senic_hub/requirements.txt (line 18))
  Downloading https://pypi.senic.com/root/pypi/+f/dcc/f2eafb7113759/venusian-1.0.tar.gz (45kB)
Collecting waitress==1.0.2 (from -r /srv/senic_hub/requirements.txt (line 19))
  Downloading https://pypi.senic.com/root/pypi/+f/d88/212877feb9801/waitress-1.0.2-py2.py3-none-any.whl (113kB)
Collecting WebOb==1.7.0rc2 (from -r /srv/senic_hub/requirements.txt (line 20))
  Downloading https://pypi.senic.com/root/pypi/+f/f4a/eb138309bd588/WebOb-1.7.0rc2-py2.py3-none-any.whl (83kB)
Requirement already up-to-date: zope.deprecation==4.2.0 in /srv/senic_hub/venv/lib/python3.5/site-packages (from -r /srv/senic_hub/requirements.txt (line 21))
Collecting zope.interface==4.3.3 (from -r /srv/senic_hub/requirements.txt (line 22))
  Downloading https://pypi.senic.com/root/pypi/+f/ba3/f32eacaea6609/zope.interface-4.3.3.tar.gz (150kB)
Collecting senic_hub (from -r /srv/senic_hub/requirements.txt (line 23))
  Downloading https://pypi.senic.com/getsenic/master/+f/96f/99e2336515a0a/senic_hub-0.0.772+29c7dea-py3-none-any.whl (11.8MB)
Collecting pycparser (from cffi==1.8.3->-r /srv/senic_hub/requirements.txt (line 2))
  Downloading https://pypi.senic.com/root/pypi/+f/ca9/8dcb50bc1276f/pycparser-2.17.tar.gz (231kB)
Requirement already up-to-date: PyYAML in /srv/senic_hub/venv/lib/python3.5/site-packages (from cryptoyaml==0.2.0->-r /srv/senic_hub/requirements.txt (line 6))
Collecting pyasn1>=0.1.8 (from cryptography==1.4->-r /srv/senic_hub/requirements.txt (line 7))
  Downloading https://pypi.senic.com/root/pypi/+f/bde/cf769ed482330/pyasn1-0.2.3-py2.py3-none-any.whl (53kB)
Requirement already up-to-date: six>=1.4.1 in /usr/lib/python3.5/site-packages (from cryptography==1.4->-r /srv/senic_hub/requirements.txt (line 7))
Requirement already up-to-date: setuptools>=11.3 in /srv/senic_hub/venv/lib/python3.5/site-packages (from cryptography==1.4->-r /srv/senic_hub/requirements.txt (line 7))
Requirement already up-to-date: pyramid-tm in /srv/senic_hub/venv/lib/python3.5/site-packages (from senic_hub->-r /srv/senic_hub/requirements.txt (line 23))
Requirement already up-to-date: websocket-client==0.40.0 in /srv/senic_hub/venv/lib/python3.5/site-packages (from senic_hub->-r /srv/senic_hub/requirements.txt (line 23))
Requirement already up-to-date: soco==0.12 in /srv/senic_hub/venv/lib/python3.5/site-packages (from senic_hub->-r /srv/senic_hub/requirements.txt (line 23))
Requirement already up-to-date: nuimo<0.4.0,>=0.3.0 in /srv/senic_hub/venv/lib/python3.5/site-packages (from senic_hub->-r /srv/senic_hub/requirements.txt (line 23))
Requirement already up-to-date: netdisco==0.9.2 in /srv/senic_hub/venv/lib/python3.5/site-packages (from senic_hub->-r /srv/senic_hub/requirements.txt (line 23))
Requirement already up-to-date: wifi in /srv/senic_hub/venv/lib/python3.5/site-packages (from senic_hub->-r /srv/senic_hub/requirements.txt (line 23))
Collecting lightify>=1.0.5 (from senic_hub->-r /srv/senic_hub/requirements.txt (line 23))

:stderr:   Could not find a version that satisfies the requirement lightify>=1.0.5 (from senic_hub->-r /srv/senic_hub/requirements.txt (line 23)) (from versions: 1.0.1, 1.0.2, 1.0.3)
No matching distribution found for lightify>=1.0.5 (from senic_hub->-r /srv/senic_hub/requirements.txt (line 23))


FATAL: all hosts have already failed -- aborting
```