### PR TITLE
Improve ios fastlane deployment

### DIFF
--- a/deployment/etc/ploy.conf
+++ b/deployment/etc/ploy.conf
@@ -82,3 +82,14 @@ roles =
     hub-ubuntu
     hub-backend
     hub-hass
+
+[plain-instance:beta]
+<= macro:hub-base
+ip = 192.168.1.22
+fabfile = ../fab_nanopi.py
+ansible-devpi_index = getsenic/master
+ansible-hub_development_mode = False
+roles =
+    hub-ubuntu
+    hub-backend
+    hub-hass

--- a/senic_hub/setup_app/README.rst
+++ b/senic_hub/setup_app/README.rst
@@ -39,7 +39,7 @@ iOS
 One time setup
 --------------
 
-* From the ``senic_hub/setup_app/ios`` direcotry run ``fastlane match adhoc`` to download signing certificates & profiles. You will be asked for encryption passphrase which you can find in 1Password entry ``Software/fastlane-match Git repository encryption passphrase``. You might be asked a password for Apple ID ``developers@senic.com``, it can be found in the 1Password entry ``Shared/Apple ID for developers@senic.com``.
+* From the ``senic_hub/setup_app/ios`` directory run ``fastlane match`` to download signing certificates & profiles. You will be asked for encryption passphrase which you can find in 1Password entry ``Software/fastlane-match Git repository encryption passphrase``. You might be asked a password for Apple ID ``developers@senic.com``, it can be found in the 1Password entry ``Shared/Apple ID for developers@senic.com``.
 
 For each release
 ----------------

--- a/senic_hub/setup_app/ios/SenicHubSetup.xcodeproj/project.pbxproj
+++ b/senic_hub/setup_app/ios/SenicHubSetup.xcodeproj/project.pbxproj
@@ -1062,7 +1062,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Senic Developer (HPWBKD7PSP)";
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = 326587HQT3;
@@ -1087,8 +1087,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.senic.hub.setupapp;
 				PRODUCT_NAME = SenicHubSetup;
-				PROVISIONING_PROFILE = "f14cb255-3fd8-4d08-ae73-2faf83de1544";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development com.senic.hub.setupapp 1497451517";
+				PROVISIONING_PROFILE = "2984ba35-6823-44f5-829a-413493bf84ea";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development com.senic.hub.setupapp";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -1098,7 +1098,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: senic GmbH (326587HQT3)";
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 326587HQT3;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1122,8 +1122,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.senic.hub.setupapp;
 				PRODUCT_NAME = SenicHubSetup;
-				PROVISIONING_PROFILE = "f42e961e-8524-403c-a1fe-d85e5bed8a0b";
-				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc com.senic.hub.setupapp 1497451425";
+				PROVISIONING_PROFILE = "aa64e7e2-1bd8-47b2-b081-b14c3c93251c";
+				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc com.senic.hub.setupapp";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/senic_hub/setup_app/ios/SenicHubSetup/Info.plist
+++ b/senic_hub/setup_app/ios/SenicHubSetup/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/senic_hub/setup_app/ios/fastlane/Fastfile
+++ b/senic_hub/setup_app/ios/fastlane/Fastfile
@@ -5,15 +5,14 @@ generated_fastfile_id "b2217ca0-6074-48b7-8bbe-05d2469de0e8"
 default_platform :ios
 
 platform :ios do
-  desc "Runs all the tests"
-  lane :test do
-    scan
-  end
-
   lane :beta do
+    disable_automatic_code_signing(
+      path: "SenicHubSetup.xcodeproj"
+    )
     match(
       type: "adhoc",
-      git_url: "git@github.com:getsenic/senic-hub-certs.git"
+      git_url: "git@github.com:getsenic/senic-hub-certs.git",
+      force_for_new_devices: true
     )
     gym(
       scheme: "SenicHubSetup",

--- a/senic_hub/setup_app/ios/fastlane/README.md
+++ b/senic_hub/setup_app/ios/fastlane/README.md
@@ -30,11 +30,6 @@ xcode-select --install
 
 # Available Actions
 ## iOS
-### ios test
-```
-fastlane ios test
-```
-Runs all the tests
 ### ios beta
 ```
 fastlane ios beta


### PR DESCRIPTION
- When we add new test devices `fastlane match` will automatically re-create provisioning profiles
- Updated the provisioning profile name so that it doesn't include the timestamp which was changing every time when provisioning profile was updated
- Updated XCode project to use correct code signing identities