### PR TITLE
Add 'netwatch' supervisor

### DIFF
--- a/senic_hub/.coveragerc
+++ b/senic_hub/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 omit =
   senic_hub/backend/commands.py
+  senic_hub/backend/netwatch.py
   senic_hub/backend/network_discovery.py
   senic_hub/backend/subprocess_run.py
   senic_hub/backend/supervisor.py

--- a/senic_hub/backend/config.py
+++ b/senic_hub/backend/config.py
@@ -26,7 +26,7 @@ def path(service):
 def configure(global_config, **settings):
     config = Configurator(settings=dict(default_settings, **settings))
     config.begin()
-    scan_ignore = ['.tests', '.testing']
+    scan_ignore = ['.tests', '.testing', '.netwatch']
     config.include('cornice')
     config.scan(ignore=scan_ignore)
     config.registry.crypto_settings = crypto_settings(global_config, **settings)

--- a/senic_hub/backend/netwatch.py
+++ b/senic_hub/backend/netwatch.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python3
+
+import click
+import dbus
+import dbus.mainloop.glib
+import logging
+import time
+import xmlrpc.client
+
+import NetworkManager
+try:
+    from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
+
+from .supervisor import start_program, stop_program
+
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+@click.pass_context
+@click.option('--wlan', '-w', required=False, help="WLAN device (default = wlan0)")
+def netwatch_cli(ctx, wlan):
+    if not wlan:
+        wlan = 'wlan0'
+    ctx.obj = NetwatchSupervisor(wlan)
+
+
+@netwatch_cli.command(name='start', help="start Netwatch supervisor")
+@click.option('--verbose', '-v', count=True, help="Print info messages (-vv for debug messages)")
+@click.pass_context
+def netwatch_start(ctx, verbose):
+    log_format = '%(asctime)s %(levelname)-5.5s [%(name)s] %(message)s'
+    if verbose >= 2:
+        logging.basicConfig(level=logging.DEBUG, format=log_format)
+    elif verbose >= 1:
+        logging.basicConfig(level=logging.INFO, format=log_format)
+    else:
+        logging.basicConfig(level=logging.WARNING, format=log_format)
+    ctx.obj.run()
+
+
+class NetwatchSupervisor(object):
+    """
+    Watches for changes in the network connection.
+    If the connection is down, Bluenet will be started to be able to use the setup app
+    to configure the Wifi connection and nuimo_app will be stopped because the setup app can
+    only connect if there are no Nuimos connected.
+    If the connection is back up, the nuimo_app will be restarted.
+    """
+
+    def __init__(self, wlan_adapter):
+        """
+        Initializes the object. It can then be started with run().
+        :param wlan_adapter: name of the WLAN adapter (i.e. 'wlan0')
+        """
+        self._wlan_adapter = wlan_adapter
+        self._bluenet_is_running = False
+        self._nuimo_app_is_running = False
+        self._bluenet_rpc = xmlrpc.client.ServerProxy('http://127.0.0.1:6459')
+
+    def run(self):
+        dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+
+        # check initial status:
+        state = NetworkManager.NetworkManager.State
+        self._on_state_changed(None, state)
+
+        # listen for changes:
+        NetworkManager.NetworkManager.OnStateChanged(self._on_state_changed)
+        logger.debug("Start listening to network status changes")
+        loop = GObject.MainLoop()
+        loop.run()
+
+    def _on_state_changed(self, nm, state, **kwargs):
+        logger.info("State changed to %d: %s" % (state, NetworkManager.const('STATE', state)))
+        if state >= NetworkManager.NM_STATE_CONNECTED_GLOBAL:
+            self._switch_to_normal_mode()
+        elif state <= NetworkManager.NM_STATE_DISCONNECTED:
+            self._switch_to_provisioning_mode()
+
+    def _switch_to_normal_mode(self):
+        while (self._bluenet_is_connected() and
+                NetworkManager.NetworkManager.State >= NetworkManager.NM_STATE_CONNECTED_LOCAL):
+            logger.debug("Waiting before leaving provisioning mode till setup app is disconnected...")
+            time.sleep(5)
+
+        if NetworkManager.NetworkManager.State < NetworkManager.NM_STATE_CONNECTED_LOCAL:
+            logger.debug("Staying in provisioning mode because connection is lost again")
+            return
+
+        logger.debug("Normal mode: Stopping Bluenet and starting nuimo_app")
+        try:
+            stop_program('bluenet')
+        except xmlrpc.client.Fault as e:
+            logger.warning("Error while stopping Bluenet: %s" % str(e))
+
+        try:
+            start_program('nuimo_app')
+        except xmlrpc.client.Fault as e:
+            if e.faultCode == 60:
+                logger.debug("nuimo_app is already running")
+                pass
+            else:
+                logger.warning("Error while starting nuimo_app: %s" % str(e))
+
+    def _switch_to_provisioning_mode(self):
+        logger.debug("Provisioning mode:  Stopping nuimo_app and starting Bluenet")
+        try:
+            stop_program('nuimo_app')
+        except xmlrpc.client.Fault as e:
+            logger.warning("Error while stopping nuimo_app: %s" % str(e))
+
+        try:
+            start_program('bluenet')
+        except xmlrpc.client.Fault as e:
+            if e.faultCode == 60:
+                logger.debug("Bluenet is already running")
+            else:
+                logger.warning("Error while starting bluenet: %s" % str(e))
+
+    def _bluenet_is_connected(self):
+        try:
+            return self._bluenet_rpc.bluenet_is_connected()
+        except OSError:
+            # -> connection refused because bluenet is not even running
+            return False
+        except (xmlrpc.client.Fault, OSError) as e:
+            logger.warning("Couldn't check if Bluenet is connected: %s" % str(e))
+        return False
+
+
+if __name__ == '__main__':
+    netwatch_cli()

--- a/senic_hub/backend/netwatch.py
+++ b/senic_hub/backend/netwatch.py
@@ -22,8 +22,7 @@ logger = logging.getLogger(__name__)
 @click.pass_context
 @click.option('--wlan', '-w', required=False, help="WLAN device (default = wlan0)")
 def netwatch_cli(ctx, wlan):
-    if not wlan:
-        wlan = 'wlan0'
+    wlan = wlan or 'wlan0'
     ctx.obj = NetwatchSupervisor(wlan)
 
 
@@ -56,8 +55,6 @@ class NetwatchSupervisor(object):
         :param wlan_adapter: name of the WLAN adapter (i.e. 'wlan0')
         """
         self._wlan_adapter = wlan_adapter
-        self._bluenet_is_running = False
-        self._nuimo_app_is_running = False
         self._bluenet_rpc = xmlrpc.client.ServerProxy('http://127.0.0.1:6459')
 
     def run(self):
@@ -65,15 +62,15 @@ class NetwatchSupervisor(object):
 
         # check initial status:
         state = NetworkManager.NetworkManager.State
-        self._on_state_changed(None, state)
+        self._on_network_state_changed(None, state)
 
         # listen for changes:
-        NetworkManager.NetworkManager.OnStateChanged(self._on_state_changed)
+        NetworkManager.NetworkManager.OnStateChanged(self._on_network_state_changed)
         logger.debug("Start listening to network status changes")
         loop = GObject.MainLoop()
         loop.run()
 
-    def _on_state_changed(self, nm, state, **kwargs):
+    def _on_network_state_changed(self, nm, state, **kwargs):
         logger.info("State changed to %d: %s" % (state, NetworkManager.const('STATE', state)))
         if state >= NetworkManager.NM_STATE_CONNECTED_GLOBAL:
             self._switch_to_normal_mode()
@@ -81,7 +78,7 @@ class NetwatchSupervisor(object):
             self._switch_to_provisioning_mode()
 
     def _switch_to_normal_mode(self):
-        while (self._bluenet_is_connected() and
+        while (self._is_bluenet_connected() and
                 NetworkManager.NetworkManager.State >= NetworkManager.NM_STATE_CONNECTED_LOCAL):
             logger.debug("Waiting before leaving provisioning mode till setup app is disconnected...")
             time.sleep(5)
@@ -90,7 +87,7 @@ class NetwatchSupervisor(object):
             logger.debug("Staying in provisioning mode because connection is lost again")
             return
 
-        logger.debug("Normal mode: Stopping Bluenet and starting nuimo_app")
+        logger.debug("Normal mode: Stopping Bluenet and starting Nuimo App")
         try:
             stop_program('bluenet')
         except xmlrpc.client.Fault as e:
@@ -100,17 +97,16 @@ class NetwatchSupervisor(object):
             start_program('nuimo_app')
         except xmlrpc.client.Fault as e:
             if e.faultCode == 60:
-                logger.debug("nuimo_app is already running")
-                pass
+                logger.debug("Nuimo App is already running")
             else:
-                logger.warning("Error while starting nuimo_app: %s" % str(e))
+                logger.warning("Error while starting Nuimo App: %s" % str(e))
 
     def _switch_to_provisioning_mode(self):
-        logger.debug("Provisioning mode:  Stopping nuimo_app and starting Bluenet")
+        logger.debug("Provisioning mode:  Stopping Nuimo App and starting Bluenet")
         try:
             stop_program('nuimo_app')
         except xmlrpc.client.Fault as e:
-            logger.warning("Error while stopping nuimo_app: %s" % str(e))
+            logger.warning("Error while stopping Nuimo App: %s" % str(e))
 
         try:
             start_program('bluenet')
@@ -118,15 +114,15 @@ class NetwatchSupervisor(object):
             if e.faultCode == 60:
                 logger.debug("Bluenet is already running")
             else:
-                logger.warning("Error while starting bluenet: %s" % str(e))
+                logger.warning("Error while starting Bluenet: %s" % str(e))
 
-    def _bluenet_is_connected(self):
+    def _is_bluenet_connected(self):
         try:
-            return self._bluenet_rpc.bluenet_is_connected()
+            return self._bluenet_rpc.is_bluenet_connected()
         except OSError:
             # -> connection refused because bluenet is not even running
             return False
-        except (xmlrpc.client.Fault, OSError) as e:
+        except xmlrpc.client.Fault as e:
             logger.warning("Couldn't check if Bluenet is connected: %s" % str(e))
         return False
 

--- a/senic_hub/bluenet/bluenet.py
+++ b/senic_hub/bluenet/bluenet.py
@@ -324,11 +324,11 @@ class BluenetDaemon(object):
         return ip
 
     def _start_rpc_server(self):
-        def bluenet_is_connected():
+        def is_bluenet_connected():
             return self._ble_peripheral.is_connected
 
         server = SimpleXMLRPCServer(('127.0.0.1', 6459), requestHandler=RequestHandler)
-        server.register_function(bluenet_is_connected)
+        server.register_function(is_bluenet_connected)
         logger.info("Starting RPC server")
         server.serve_forever()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,17 @@
 [tool:pytest]
 addopts =
-	--strict
-	--flakes
-	--pep8
+    --strict
+    --flakes
+    --pep8
     --cov-config senic_hub/.coveragerc
-	--cov-report=term
-	--cov-report=html
-	--doctest-modules
-	senic_hub/backend
+    --cov-report=term
+    --cov-report=html
+    --ignore=senic_hub/backend/netwatch.py
+    --doctest-modules
+    senic_hub/backend
     senic_hub/nuimo_app
-omit = senic_hub/backend/testing.py
+omit =
+    senic_hub/backend/testing.py
 pep8ignore = E501 E128 E731
 norecursedirs = senic_hub/backend/migrations
 

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         main = senic_hub.backend:main
         [console_scripts]
         wifi_setup = senic_hub.backend.wifi_setup:wifi_setup
+        netwatch = senic_hub.backend.netwatch:netwatch_cli
         bluenet = senic_hub.bluenet.bluenet:bluenet_cli
         scan_wifi = senic_hub.backend.wifi_setup:scan_wifi
         create_configurations = senic_hub.backend.commands:create_configuration_files_and_restart_apps


### PR DESCRIPTION
Adds a supervisor that switches between normal and provisioning mode.
In normal mode nuimo_app is running and Bluenet not while in provisioning mode Bluenet is started and nuimo_app is stopped.

This is necessary because the setup app cannot be connected while Nuimos are connected and the other way around.