### PR TITLE
Add Netwatch and use D-Bus lib for Bluenet

### DIFF
--- a/deployment/roles/hub-backend/tasks/main.yml
+++ b/deployment/roles/hub-backend/tasks/main.yml
@@ -105,7 +105,7 @@
 - name: initialize cryptoyaml key
   become: true
   become_user: "{{build_user}}"
-  command: "{{backend_deploy_location}}/venv/bin/cryptoyaml generate_key {{backend_deploy_location}}/production.key"
+  command: "cryptoyaml generate_key {{backend_deploy_location}}/production.key"
   args:
     chdir: "{{backend_deploy_location}}"
     creates: "{{backend_deploy_location}}/production.key"
@@ -115,7 +115,7 @@
 
 - name: initialize cryptoyaml settings
   become: true
-  command: "{{backend_deploy_location}}/venv/bin/cryptoyaml create {{backend_deploy_location}}/production.yml.aes --keyfile {{backend_deploy_location}}/production.key"
+  command: "cryptoyaml create {{backend_deploy_location}}/production.yml.aes --keyfile {{backend_deploy_location}}/production.key"
   args:
     chdir: "{{backend_deploy_location}}"
     creates: "{{backend_deploy_location}}/production.yml.aes"

--- a/deployment/roles/hub-ubuntu/tasks/main.yml
+++ b/deployment/roles/hub-ubuntu/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# thsee are the platform specific setup steps for the hub on 
+# these are the platform specific setup steps for the hub on
 # an ubuntu or debian like system
 # - include: dhcp.yml
 #   tags: dhcp
@@ -23,6 +23,7 @@
     - device_discovery
     - nuimo_app
     - bluenet
+    - netwatch
 #  notify: reload supervisord
   tags: supervisor
 

--- a/deployment/roles/hub-ubuntu/templates/netwatch_supervisor.conf
+++ b/deployment/roles/hub-ubuntu/templates/netwatch_supervisor.conf
@@ -1,6 +1,6 @@
 [program:{{item}}]
-command = {{backend_deploy_location}}/venv/bin/{{item}} -b hci0 -w wlan0 start -vv -h http://%%IP:6543/-/ -a 'Senic Hub'
-autostart=false
+command = {{backend_deploy_location}}/venv/bin/{{item}} start
+autostart=true
 autorestart=true
 directory={{ backend_deploy_location }}
 stdout_logfile={{ backend_data_location }}/{{item}}.log

--- a/deployment/roles/hub-ubuntu/templates/nuimo_app_supervisor.conf
+++ b/deployment/roles/hub-ubuntu/templates/nuimo_app_supervisor.conf
@@ -6,7 +6,7 @@ environment=LC_ALL={{locale}}, LANG={{locale}}
 command = {{backend_deploy_location}}/venv/bin/nuimo_app -c {{backend_deploy_location}}/production.ini
 environment=LC_ALL={{locale}}, LANG={{locale}}, SENTRY_DSN="{{sentry_dsn}}"
 {% endif %}
-autostart=true
+autostart=false
 autorestart=true
 directory={{ backend_deploy_location }}
 stdout_logfile={{ backend_data_location }}/nuimo_app.log

--- a/senic_hub/backend/netwatch.py
+++ b/senic_hub/backend/netwatch.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python3
+
+import click
+import dbus
+import dbus.mainloop.glib
+import logging
+import time
+import xmlrpc.client
+
+import NetworkManager
+try:
+    from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
+
+from .supervisor import start_program, stop_program
+
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+@click.pass_context
+@click.option('--wlan', '-w', required=False, help="WLAN device (default = wlan0)")
+def netwatch_cli(ctx, wlan):
+    if not wlan:
+        wlan = 'wlan0'
+    ctx.obj = NetwatchSupervisor(wlan)
+
+
+@netwatch_cli.command(name='start', help="start Netwatch supervisor")
+@click.option('--verbose', '-v', count=True, help="Print info messages (-vv for debug messages)")
+@click.pass_context
+def netwatch_start(ctx, verbose):
+    log_format = '%(asctime)s %(levelname)-5.5s [%(name)s] %(message)s'
+    if verbose >= 2:
+        logging.basicConfig(level=logging.DEBUG, format=log_format)
+    elif verbose >= 1:
+        logging.basicConfig(level=logging.INFO, format=log_format)
+    else:
+        logging.basicConfig(level=logging.WARNING, format=log_format)
+    ctx.obj.run()
+
+
+class NetwatchSupervisor(object):
+    """
+    Watches for changes in the network connection.
+    If the connection is down, Bluenet will be started to be able to use the setup app
+    to configure the Wifi connection and nuimo_app will be stopped because the setup app can
+    only connect if there are no Nuimos connected.
+    If the connection is back up, the nuimo_app will be restarted.
+    """
+
+    def __init__(self, wlan_adapter):
+        """
+        Initializes the object. It can then be started with run().
+        :param wlan_adapter: name of the WLAN adapter (i.e. 'wlan0')
+        """
+        self._wlan_adapter = wlan_adapter
+        self._bluenet_is_running = False
+        self._nuimo_app_is_running = False
+        self._bluenet_rpc = xmlrpc.client.ServerProxy('http://127.0.0.1:6459')
+
+    def run(self):
+        dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+
+        # check initial status:
+        state = NetworkManager.NetworkManager.State
+        self._on_state_changed(None, state)
+
+        # listen for changes:
+        NetworkManager.NetworkManager.OnStateChanged(self._on_state_changed)
+        logger.debug("Start listening to network status changes")
+        loop = GObject.MainLoop()
+        loop.run()
+
+    def _on_state_changed(self, nm, state, **kwargs):
+        logger.info("State changed to %d: %s" % (state, NetworkManager.const('STATE', state)))
+        if state >= NetworkManager.NM_STATE_CONNECTED_GLOBAL:
+            self._switch_to_normal_mode()
+        elif state <= NetworkManager.NM_STATE_DISCONNECTED:
+            self._switch_to_provisioning_mode()
+
+    def _switch_to_normal_mode(self):
+        while (self._bluenet_is_connected() and
+                NetworkManager.NetworkManager.State >= NetworkManager.NM_STATE_CONNECTED_LOCAL):
+            logger.debug("Waiting before leaving provisioning mode till setup app is disconnected...")
+            time.sleep(5)
+
+        if NetworkManager.NetworkManager.State < NetworkManager.NM_STATE_CONNECTED_LOCAL:
+            logger.debug("Staying in provisioning mode because connection is lost again")
+            return
+
+        logger.debug("Normal mode: Stopping Bluenet and starting nuimo_app")
+        try:
+            stop_program('bluenet')
+        except xmlrpc.client.Fault as e:
+            logger.warning("Error while stopping Bluenet: %s" % str(e))
+
+        try:
+            start_program('nuimo_app')
+        except xmlrpc.client.Fault as e:
+            if e.faultCode == 60:
+                logger.debug("nuimo_app is already running")
+                pass
+            else:
+                logger.warning("Error while starting nuimo_app: %s" % str(e))
+
+    def _switch_to_provisioning_mode(self):
+        logger.debug("Provisioning mode:  Stopping nuimo_app and starting Bluenet")
+        try:
+            stop_program('nuimo_app')
+        except xmlrpc.client.Fault as e:
+            logger.warning("Error while stopping nuimo_app: %s" % str(e))
+
+        try:
+            start_program('bluenet')
+        except xmlrpc.client.Fault as e:
+            if e.faultCode == 60:
+                logger.debug("Bluenet is already running")
+            else:
+                logger.warning("Error while starting bluenet: %s" % str(e))
+
+    def _bluenet_is_connected(self):
+        try:
+            return self._bluenet_rpc.bluenet_is_connected()
+        except OSError:
+            # -> connection refused because bluenet is not even running
+            return False
+        except (xmlrpc.client.Fault, OSError) as e:
+            logger.warning("Couldn't check if Bluenet is connected: %s" % str(e))
+        return False
+
+
+if __name__ == '__main__':
+    netwatch_cli()

--- a/senic_hub/backend/netwatch.py
+++ b/senic_hub/backend/netwatch.py
@@ -90,7 +90,7 @@ class NetwatchSupervisor(object):
             logger.debug("Staying in provisioning mode because connection is lost again")
             return
 
-        logger.debug("Normal mode: Stopping Bluenet and starting nuimo_app")
+        logger.debug("Normal mode: Stopping Bluenet and starting Nuimo App")
         try:
             stop_program('bluenet')
         except xmlrpc.client.Fault as e:
@@ -103,14 +103,14 @@ class NetwatchSupervisor(object):
                 logger.debug("nuimo_app is already running")
                 pass
             else:
-                logger.warning("Error while starting nuimo_app: %s" % str(e))
+                logger.warning("Error while starting Nuimo App: %s" % str(e))
 
     def _switch_to_provisioning_mode(self):
-        logger.debug("Provisioning mode:  Stopping nuimo_app and starting Bluenet")
+        logger.debug("Provisioning mode:  Stopping Nuimo App and starting Bluenet")
         try:
             stop_program('nuimo_app')
         except xmlrpc.client.Fault as e:
-            logger.warning("Error while stopping nuimo_app: %s" % str(e))
+            logger.warning("Error while stopping Nuimo App: %s" % str(e))
 
         try:
             start_program('bluenet')

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         [paste.app_factory]
         main = senic_hub.backend:main
         [console_scripts]
+        netwatch = senic_hub.backend.netwatch:netwatch_cli
         bluenet = senic_hub.bluenet.bluenet:bluenet_cli
         device_discovery = senic_hub.backend.commands:device_discovery
         nuimo_app = senic_hub.nuimo_app.__main__:main


### PR DESCRIPTION
This PR includes #194:
Adds a supervisor that switches between normal and provisioning mode.
In normal mode nuimo_app is running and Bluenet not while in provisioning mode Bluenet is started and nuimo_app is stopped.
This is necessary because the setup app cannot be connected while Nuimos are connected and the other way around.

In addition it replaces all commandline calls in Bluenet with the NetworkManager D-Bus library.

**Important:**
This PR works only with the new Senic OS image that includes python-networkmanager and python-pydoc. This means that it should only be merged when this image is in the stable branch.

TODOs for the Senic OS image:
- change line 108 and 118 in `deployment/roles/hub-backend/tasks/main.yml` to point to `/usr/bin/cryptoyaml` [edit: fixed this directly in this PR]
- `/home/senic` folder isn't created in provisioning
- password request appears for root user in provisioning commands