### PR TITLE
Change wifi connection name, fix RPC method

### DIFF
--- a/senic_hub/backend/netwatch.py
+++ b/senic_hub/backend/netwatch.py
@@ -122,7 +122,7 @@ class NetwatchSupervisor(object):
 
     def _bluenet_is_connected(self):
         try:
-            return self._bluenet_rpc.bluenet_is_connected()
+            return self._bluenet_rpc.is_bluenet_connected()
         except OSError:
             # -> connection refused because bluenet is not even running
             return False

--- a/senic_hub/bluenet/bluenet.py
+++ b/senic_hub/bluenet/bluenet.py
@@ -21,7 +21,7 @@ from .bluenet_gatt_service import BluenetService, BluenetUuids, WifiConnectionSt
 #: Name of the NetworkManager connection to use for BLE provisioning
 #: It will be created on first attempt to join a network
 #: or overwritten if it already exists.
-NM_CONNECTION_NAME = 'Bluenet'
+NM_CONNECTION_NAME = 'bluenet'
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Changes the wifi connection name that Bluenet uses to lower case and fixes a wrong method name in the RPC commnication between bluenet and netwatch.