### PR TITLE
Fix hue username removed during discovery

### DIFF
--- a/senic_hub/backend/commands.py
+++ b/senic_hub/backend/commands.py
@@ -144,7 +144,7 @@ def device_discovery(config):
         add_device_details(merged_devices)
         add_homeassistant_entity_ids(merged_devices)
 
-        fd, filename = mkstemp(dir=app.registry.settings['homeassistant_data_path'])
+        fd, filename = mkstemp(dir=app.registry.settings['data_path'])
         with open(fd, "w") as f:
             json.dump(merged_devices, f)
         os.rename(filename, devices_path)

--- a/senic_hub/backend/device_discovery.py
+++ b/senic_hub/backend/device_discovery.py
@@ -143,7 +143,6 @@ class PhilipsHueBridgeApiClient:
             data = data[0]
 
         if "error" in data:
-            logger.error("Response from Hue bridge %s: %s", self.bridge_url, data)
             error_type = data["error"]["type"]
             if error_type in [
                     PhilipsHueBridgeError.unauthorized,

--- a/senic_hub/backend/device_discovery.py
+++ b/senic_hub/backend/device_discovery.py
@@ -40,11 +40,13 @@ class PhilipsHueBridgeError(IntEnum):
 logger = logging.getLogger(__name__)
 
 
-def discover_devices(devices, now):
-    all_devices = []
-    known_devices = deepcopy(devices)
+def merge_devices(known_devices, discovered_devices, now):
+    # TODO: Do we need to make a deep copy? Are arrays not passed by-value, but by-ref?
+    known_devices = deepcopy(known_devices)
 
-    discovered_devices = discover()
+    # TODO: `merged_devices` can be directly assigned with a list comprehension
+    merged_devices = []
+
     for device in discovered_devices:
         # make sure we get updates for devices we already had discovered before
         existing_device = next((d for d in known_devices if d["id"] == device["id"]), None)
@@ -58,16 +60,16 @@ def discover_devices(devices, now):
                 known_devices.remove(existing_device)
 
         device[DISCOVERY_TIMESTAMP_FIELD] = str(now)
-        all_devices.append(device)
+        merged_devices.append(device)
 
     # add already known devices that were not found in this discovery
     # run or it was found that they didn't have any updates
-    all_devices.extend(known_devices)
+    merged_devices.extend(known_devices)
 
-    return sorted(all_devices, key=lambda d: d["id"])
+    return sorted(merged_devices, key=lambda d: d["id"])
 
 
-def discover(discovery_class=NetworkDiscovery):
+def discover_devices(discovery_class=NetworkDiscovery):
     """
     Return a list of all discovered devices.
 

--- a/senic_hub/backend/device_discovery.py
+++ b/senic_hub/backend/device_discovery.py
@@ -49,15 +49,17 @@ def merge_devices(known_devices, discovered_devices, now):
 
     for device in discovered_devices:
         # make sure we get updates for devices we already had discovered before
-        existing_device = next((d for d in known_devices if d["id"] == device["id"]), None)
-        if existing_device:
-            # device already known, check if we should update any fields
-            if {k: v for k, v in existing_device.items() if k != DISCOVERY_TIMESTAMP_FIELD} == device:
-                # all fields match, use the already known device
-                continue
-            else:
-                # fields don't match, device will added as new
-                known_devices.remove(existing_device)
+        known_device = next((d for d in known_devices if d["id"] == device["id"]), None)
+        if known_device:
+            known_devices.remove(known_device)
+
+            # Copy "extra" attributes from existing device if not present in newly found
+            # device. These attributes are typically added later such as during
+            # authentication of Philipe Hue bridge.
+            merged_extra = known_device.get('extra', None)
+            if merged_extra:
+                merged_extra.update(device.get('extra', {}))
+                device['extra'] = merged_extra
 
         device[DISCOVERY_TIMESTAMP_FIELD] = str(now)
         merged_devices.append(device)

--- a/senic_hub/backend/lockfile.py
+++ b/senic_hub/backend/lockfile.py
@@ -1,0 +1,38 @@
+from fasteners import InterProcessLock
+
+
+def open_locked(file, mode, buffering=-1, encoding=None, errors=None, newline=None, closefd=True):
+    """
+    Returns an instance of `FileLock` that can be used in a with statement.
+
+    If used in a with statement, an inter-process lock for `file` will be acquired and the file
+    will be opened. If the file is already locked by another `open_locked` call then the call
+    blocks until the lock has been released. When the with statement has completed, the lock
+    will be released. The lock is stored in a file with the same filename that additionally
+    carries a .lock extension.
+
+    All file related parameters are the same as in Python's `open()` method as they are simply
+    forwarded to `open()`.
+    """
+    return _LockFile(file, mode, buffering, encoding, errors, newline, closefd)
+
+
+class _LockFile:
+    def __init__(self, file, mode, buffering, encoding, errors, newline, closefd):
+        self.file = file
+        self.mode = mode
+        self.buffering = buffering
+        self.encoding = encoding
+        self.errors = errors
+        self.newline = newline
+        self.closefd = closefd
+        self.f = None
+        self.lock = InterProcessLock(file + '.lock')
+
+    def __enter__(self):
+        with self.lock:
+            self.f = open(self.file, self.mode, self.buffering, self.encoding, self.errors, self.newline, self.closefd)
+            return self.f
+
+    def __exit__(self, type, value, traceback):
+        self.f.close()

--- a/senic_hub/backend/tests/test_device_discovery.py
+++ b/senic_hub/backend/tests/test_device_discovery.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from pytest import fixture, raises
 
 import responses
 
 from senic_hub.backend.device_discovery import (
-    DISCOVERY_TIMESTAMP_FIELD, UpstreamError, discover, discover_devices, get_device_description)
+    DISCOVERY_TIMESTAMP_FIELD, UpstreamError, discover_devices, merge_devices, get_device_description)
 
 
 @fixture
@@ -109,11 +109,11 @@ def test_discover_philips_hue_device(philips_hue_bridge_description):
         "ip": "127.0.0.1",
         "extra": {},
     }
-    assert discover(MockPhilipsDiscovery) == [expected]
+    assert discover_devices(MockPhilipsDiscovery) == [expected]
 
 
 def test_discover_devices_for_the_first_time_return_all_devices():
-    devices = []
+    known_devices = []
     discovered_devices = [{
         "id": "1",
         "name": "first",
@@ -131,14 +131,12 @@ def test_discover_devices_for_the_first_time_return_all_devices():
         "name": "second",
         DISCOVERY_TIMESTAMP_FIELD: str(now),
     }]
-    with patch("senic_hub.backend.device_discovery.discover") as discover_mock:
-        discover_mock.return_value = discovered_devices
-        assert discover_devices(devices, now) == expected
+    assert merge_devices(known_devices, discovered_devices, now) == expected
 
 
 def test_discover_devices_includes_new_device_discovered():
     now = datetime.utcnow()
-    devices = [{
+    known_devices = [{
         "id": "1",
         "name": "first",
         DISCOVERY_TIMESTAMP_FIELD: str(now - timedelta(minutes=2)),
@@ -159,14 +157,12 @@ def test_discover_devices_includes_new_device_discovered():
         "name": "second",
         DISCOVERY_TIMESTAMP_FIELD: str(now),
     }]
-    with patch("senic_hub.backend.device_discovery.discover") as discover_mock:
-        discover_mock.return_value = discovered_devices
-        assert discover_devices(devices, now) == expected
+    assert merge_devices(known_devices, discovered_devices, now) == expected
 
 
 def test_discover_devices_update_device_with_updated_fields():
     now = datetime.utcnow()
-    devices = [{
+    known_devices = [{
         "id": "1",
         "name": "first",
         DISCOVERY_TIMESTAMP_FIELD: str(now - timedelta(minutes=2)),
@@ -187,14 +183,12 @@ def test_discover_devices_update_device_with_updated_fields():
         "name": "second",
         DISCOVERY_TIMESTAMP_FIELD: str(now),
     }]
-    with patch("senic_hub.backend.device_discovery.discover") as discover_mock:
-        discover_mock.return_value = discovered_devices
-        assert discover_devices(devices, now) == expected
+    assert merge_devices(known_devices, discovered_devices, now) == expected
 
 
 def test_discover_devices_device_that_wasnt_discovered_again_is_not_removed_from_the_devices_list():
     now = datetime.utcnow()
-    devices = [{
+    known_devices = [{
         "id": "1",
         "name": "first",
         DISCOVERY_TIMESTAMP_FIELD: str(now),
@@ -207,7 +201,5 @@ def test_discover_devices_device_that_wasnt_discovered_again_is_not_removed_from
         "id": "1",
         "name": "first",
     }]
-    expected = devices
-    with patch("senic_hub.backend.device_discovery.discover") as discover_mock:
-        discover_mock.return_value = discovered_devices
-        assert discover_devices(devices, now) == expected
+    expected = known_devices
+    assert merge_devices(known_devices, discovered_devices, now) == expected

--- a/senic_hub/backend/tests/test_device_discovery.py
+++ b/senic_hub/backend/tests/test_device_discovery.py
@@ -151,7 +151,7 @@ def test_discover_devices_includes_new_device_discovered():
     expected = [{
         "id": "1",
         "name": "first",
-        DISCOVERY_TIMESTAMP_FIELD: str(now - timedelta(minutes=2)),
+        DISCOVERY_TIMESTAMP_FIELD: str(now),
     }, {
         "id": "2",
         "name": "second",
@@ -200,6 +200,35 @@ def test_discover_devices_device_that_wasnt_discovered_again_is_not_removed_from
     discovered_devices = [{
         "id": "1",
         "name": "first",
+    }]
+    expected = known_devices
+    assert merge_devices(known_devices, discovered_devices, now) == expected
+
+
+def test_merging_devices_keeps_hue_username():
+    now = datetime.utcnow()
+    known_devices = [{
+        "id": "1",
+        "type": "philips_hue",
+        DISCOVERY_TIMESTAMP_FIELD: str(now),
+        'extra': {
+            'username': 'light-bringer',
+        },
+    }, {
+        "id": "2",
+        "type": "philips_hue",
+        DISCOVERY_TIMESTAMP_FIELD: str(now),
+        'extra': {
+            'username': 'another-light-bringer',
+        },
+    }]
+    discovered_devices = [{
+        "id": "1",
+        "type": "philips_hue",
+    }, {
+        "id": "2",
+        "type": "philips_hue",
+        'extra': {},
     }]
     expected = known_devices
     assert merge_devices(known_devices, discovered_devices, now) == expected

--- a/senic_hub/backend/tests/test_filelock.py
+++ b/senic_hub/backend/tests/test_filelock.py
@@ -1,0 +1,27 @@
+from os import remove
+from shutil import copyfile
+from tempfile import mkstemp
+
+from senic_hub.backend.lockfile import open_locked
+
+
+def test_file_can_be_locked_and_read(settings):
+    file = settings['nuimo_mac_address_filepath']
+    with open_locked(file, 'r') as f:
+        assert f.readline().strip() == 'AA:BB:CC:DD:EE:FF'
+
+
+def test_file_can_be_locked_and_read_and_written(settings):
+    file = mkstemp()[1]
+    copyfile(settings['nuimo_mac_address_filepath'], file)
+    try:
+        with open_locked(file, 'r+') as f:
+            assert f.readline().strip() == 'AA:BB:CC:DD:EE:FF'
+            f.seek(0)
+            f.truncate()
+            f.write("Pablo Picasso: I don't search, I find")
+
+        with open(file, 'r') as f:
+            assert f.readline().strip() == "Pablo Picasso: I don't search, I find"
+    finally:
+        remove(file)

--- a/senic_hub/backend/views/setup_devices.py
+++ b/senic_hub/backend/views/setup_devices.py
@@ -176,7 +176,7 @@ def update_device(device, settings, username):
 
     devices[device_index] = device
 
-    fd, filename = mkstemp(dir=settings['homeassistant_data_path'])
+    fd, filename = mkstemp(dir=settings['data_path'])
     with open(fd, "w") as f:
         json.dump(devices, f)
     os.rename(filename, devices_path)

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     setuptools >= 31.0.0
     devpi-client
     docutils
+    fasteners
     flake8
     jinja2
     mock


### PR DESCRIPTION
The device discovery wasn't properly merging already discovered devices with devices from the latest discovery run. When the discovery merged devices from `devices.json` with the same devices that had been re-discovered, it was overwriting the hub bridge device and thus loosing the username that we retrieved from an earlier authentication.

Furthermore this PR introduces a `open_locked` function that can synchronous access to a file across processes. That's necessary as we have 2 processes both read and writing  `devices.json` – namely `device_discovery` (the background device discovery process) and `senic_hub` (the REST API through which the frontend triggers device authentication).