### PR TITLE
Vanilla onboarding

### DIFF
--- a/senic_hub/backend/commands.py
+++ b/senic_hub/backend/commands.py
@@ -20,12 +20,17 @@ import os
 import time
 
 
-def create_configuration_files_and_restart_apps(settings):
-    """ create_configuration_files_and_restart_apps
+def create_nuimo_app_cfg(settings):
+    """
+    Creates nuimo_app.cfg a hard dependency for nuimo_app
 
-    This is tightly coupled with the existence of
-    /data/senic-hub/devices.json
-    which probably somethin device_discovery creates
+    When there is no wifi present, netwatch kills the nuimo_app.
+    This methog responsible for the initial starting of the nuimo_app
+    once the hub got wifi connection the first time.
+    This happens during the hub onboarding.
+
+    Once the hub has been onboarded, the nuimo_app is started
+    by default by supervisor.
     """
 
     logger.info("Creating config files that map Nuimo to Sonos/Hue")
@@ -74,7 +79,6 @@ def create_configuration_files_and_restart_apps(settings):
             logger.debug("Writing %s into %s" % (config, nuimo_app_config_file_path))
             yaml.dump(config, f, default_flow_style=False)
 
-    # ALAN Netwatch isn't starting nuimo_app anymore
     if supervisor.program_status('nuimo_app') != 'RUNNING':
         supervisor.start_program('nuimo_app')
 
@@ -122,10 +126,6 @@ def phue_bridge_config(bridge):
 
 def generate_nuimo_app_configuration(nuimo_mac_address, devices):
     components = [create_component(d) for d in devices if d["authenticated"]]
-
-#    What are components?
-#    (Epdb) components
-#    [{'type': 'sonos', 'name': '10.10.10.114 - Sonos One', 'ip_address': '10.10.10.114', 'id': 'a6367f28-9363-445e-ab07-dd69f54f51ca', 'device_ids': ['7828ca17171e01400']}]
 
     config = {'nuimos': {}}
     config['nuimos'][nuimo_mac_address] = {

--- a/senic_hub/backend/commands.py
+++ b/senic_hub/backend/commands.py
@@ -16,13 +16,31 @@ COMPONENT_FOR_TYPE = {
 logger = logging.getLogger(__name__)
 
 import os.path
+import os
+import time
 
 
 def create_configuration_files_and_restart_apps(settings):
+    """ create_configuration_files_and_restart_apps
+
+    This is tightly coupled with the existence of
+    /data/senic-hub/devices.json
+    which probably somethin device_discovery creates
+    """
+
+    logger.info("Creating config files that map Nuimo to Sonos/Hue")
+
+    while not os.path.exists(settings['devices_path']):
+        logger.info("Waiting for Sonos or Hue to be detected")
+        logger.debug("Can't continue until %s has been created" %
+                     settings['devices_path'])
+        time.sleep(5)
+
     try:
         with open(settings['devices_path'], 'r') as f:
             devices = json.load(f)
-    except (FileNotFoundError, json.decoder.JSONDecodeError) as e:
+    except (json.decoder.JSONDecodeError) as e:
+        logger.error("%s doesn't contain a readable json" % settings['devices_path'])
         logger.error(e)
 
     nuimo_mac_address_file_path = settings['nuimo_mac_address_filepath']

--- a/senic_hub/backend/device_discovery.py
+++ b/senic_hub/backend/device_discovery.py
@@ -58,7 +58,7 @@ def command(config, verbose):  # pragma: no cover
     elif verbose >= 1:
         logger.setLevel(logging.INFO)
     else:
-        logger.setLevel(logging.INFO)
+        logger.setLevel(logging.WARNING)
 
     logging.getLogger("urllib3.connectionpool").setLevel(logging.CRITICAL)
 

--- a/senic_hub/backend/netwatch.py
+++ b/senic_hub/backend/netwatch.py
@@ -46,7 +46,7 @@ def netwatch_start(ctx, verbose):
     elif verbose >= 1:
         logger.setLevel(logging.INFO)
     else:
-        logger.setLevel(logging.INFO)
+        logger.setLevel(logging.WARNING)
 
     ctx.obj.run()
 

--- a/senic_hub/backend/nuimo_setup.py
+++ b/senic_hub/backend/nuimo_setup.py
@@ -2,22 +2,80 @@ import logging
 import nuimo
 import gatt
 import threading
-
+import time
+import subprocess
 
 logger = logging.getLogger(__name__)
+
+# If any of these timeouts are reached,
+# both BlueZ and the bluetooth module
+# (via the reset pin) are reset
+# and the proces is retried
+DISCOVERY_TIMEOUT = 5
+CONNECTION_TIMEOUT = 10
+
+# Onboarding in the context of this file means
+# a succefull discovery and connecion to a nuimo
+MAX_ONBOARDING_ATTEMPTS = 3
 
 
 class NuimoSetup(nuimo.ControllerManagerListener, nuimo.ControllerListener):  # pragma: no cover
 
     def __init__(self, adapter_name):
-        self._gatt_manager = gatt.DeviceManager(adapter_name)
-        self._manager = nuimo.ControllerManager(adapter_name)
+        self._adapter_name = adapter_name
+        self._gatt_manager = gatt.DeviceManager(self._adapter_name)
+        self._manager = nuimo.ControllerManager(self._adapter_name)
         self._manager.listener = self
         self._is_running = False  # Prevents from considering D-Bus events if we aren't running
         self._discovery_timeout_timer = None
         self._connect_timeout_timer = None
         self._controller = None
         self._required_mac_address = None
+        self._discovery_duration = None
+        self._connect_duration = None
+        self._nuimo_connected = False
+        self._nuimo_onboarding_attempts = 0
+
+        # A control flag not to do any action while restart
+        # is underway
+        self._bt_restart_underway = False
+
+    def _restart_bluetooth(self):
+        """
+        Restarts BlueZ and hard resets the BT module.
+
+        Sets the self._bt_restart_underway to false
+        to signal the end of bt restart.
+
+        It also reinitialises the python objects of this class
+        responsible for interacting with the underlying bt infrastructure.
+        """
+
+        hard_reset_module_cmd = "systemctl restart enable-bt-module"
+        restart_bluez_cmd = "systemctl restart bluetooth"
+
+        logger.debug("Hard restarting systemd bluetooth related services")
+        subprocess.run(hard_reset_module_cmd.split())
+        subprocess.run(restart_bluez_cmd.split())
+
+        # Reinitialise the depend on the bt module
+        # Assumed this is needed, not confirmed
+        logger.debug("Reinitialisng python object after restart")
+        del self._gatt_manager
+        del self._manager
+        self._gatt_manager = gatt.DeviceManager(self._adapter_name)
+        self._manager = nuimo.ControllerManager(self._adapter_name)
+
+        # This smells like it could cause trouble.
+        # Do doubt it for it wasn't thought of deeply.
+        del self._manager.listener
+        self._manager.listener = self
+        self._controller = None
+
+        logger.debug("Powering BT module after restart")
+        self._manager.is_adapter_powered = True
+        self._bt_restart_underway = False
+        logger.info("Bluetooth restart done")
 
     def discover_and_connect_controller(self, required_mac_address=None, timeout=None):
         """
@@ -27,96 +85,230 @@ class NuimoSetup(nuimo.ControllerManagerListener, nuimo.ControllerListener):  # 
         :param timeout: Timeout in seconds after which we stop the discovery
         :return: MAC address of connected Nuimo controller or `None` if none connected
         """
-        logger.info("Discover and connect Nuimo controller with timeout = %f", timeout)
+
+        # Inherited, didn't question it.
+        # This is the only part where gatt is used directly
+        # for all other bt operations nuimo.ControllerManager is used
         self._gatt_manager.remove_all_devices(skip_alias='Nuimo')
 
+        # Same thing as:
+        #    echo "power on" | bluetoothctl
         self._manager.is_adapter_powered = True
-        # If there's already a connected Nuimo, take it and don't run discovery
 
-        # [ALAN] The self._manager.controllers() can return a list of
-        # controllers even after factory reset.
-        # That could be some kind of bluetooth memory mechanism to utilize?
-        for controller in self._manager.controllers():
-            if controller.is_connected():
-                logger.info("Already connected controller %s, looking for another one", controller.mac_address)
-        # Start discovery
-        self._required_mac_address = required_mac_address
-        self._is_running = True
-        if timeout:
-            self._discovery_timeout_timer = threading.Timer(timeout, self.discovery_timed_out)
-            self._discovery_timeout_timer.start()
-        self._controller = None
-        self._manager.start_discovery()
-        # Start D-Bus event loop. This call is blocking until the loop gets stopped.
-        # Will be stopped when a controller was connected (see below).
-        # [ALAN] It's in the self._manager.run() that the physical nuimo 
-        # shows the checked sign
-        self._manager.run()
-        self._is_running = False
-        logger.debug("Stopped")
-        if self._discovery_timeout_timer:
-            self._discovery_timeout_timer.cancel()
-        if self._connect_timeout_timer:
-            self._connect_timeout_timer.cancel()
+        # This is the main loop for establishing a connection a new nuimo.
+        while True:
+            self._nuimo_onboarding_attempts += 1
+            self._start_onboarding()
+            if self._nuimo_connected:
+                break
+            if self._nuimo_onboarding_attempts == MAX_ONBOARDING_ATTEMPTS:
+                break
+            while self._bt_restart_underway:
+                logger.debug("Bluetooth restart underway... waiting")
+                time.sleep(2)
+
         if self._controller and self._controller.is_connected():
+            logger.info("Discovery[%d] and connection[%d] took %ds" % (
+                        self._discovery_duration,
+                        self._connect_duration,
+                        self._discovery_duration + self._connect_duration))
             return self._controller.mac_address
         else:
+            logger.info("Failed to onboard a Nuimo after %s attempts" %
+                        self._nuimo_onboarding_attempts)
             return None
 
-    def _restart_discovery(self):
-        if not self._is_running:
-            return
-        logger.debug("restarting discovery")
+    def _start_onboarding(self):
+        """
+        Blocking. Detects and connects to a nuimo, restarts BT on timeout.
+
+        Initiates the discovery process which blocks until the nuimo
+        is found and connected or it timed out.
+        """
+        logger.debug("Staring discovery timer [%ss]" % DISCOVERY_TIMEOUT)
+        self._discovery_timeout_timer = threading.Timer(DISCOVERY_TIMEOUT, self.discovery_timed_out)
+        self._discovery_timeout_timer.start()
+        self._start_discovery()
+
+    def _start_discovery(self):
+        """
+        Blocking & asynchronous. Starts the nuimo discovery.
+
+        Initiates the discovery process which triggers the bt module
+        to do the scan. Ends in a blocking call that triggers the catching
+        of catching of callbacks (asynchronous).
+        It is a bit controverse termonology but seems to fit :)
+
+        It the background that call start the d-bus event loop enables
+        allows bt related callback methods to be trigerred.
+
+        On succesfull discovery 'controller_discovered' is called
+        on timeout 'discovery_timed_out'.
+        Both callbacks explicitly call self._manager.stop()
+        causing this method to return.
+
+        On success, this is a process which coresponds to the CLI.
+        Running:
+             root@senic-hub:~# nuimoctl --discover --adapter hci0
+             Terminate with Ctrl+C
+             Discovered Nuimo controller f5:d4:41:9c:86:b0
+             Discovered Nuimo controller e0:88:72:c4:49:c2
+
+        Running the CLI in paralel has an influence on the state
+        of self._manager.controllers()
+        """
+
+        logger.info("Starting Nuimo onboarding [attempt %s]" % self._nuimo_onboarding_attempts)
+        self._is_running = True
+        self._discovery_duration = time.time()
+
+        # This will trigger the discovery in terms of a d-bus command.
+        # https://github.com/getsenic/gatt-python/blob/master/gatt/gatt_linux.py#L139
         self._manager.start_discovery()
+        self._manager.run()
 
     def discovery_timed_out(self):
+        """
+        Callback. _start_discovery timed out.
+
+        Stops all bluetooth related actuivity and
+        initiates BT restart.
+        """
+
+        # Why is this false?
         if not self._is_running:
             return
-        logger.debug("Discovery timed out, stopping now")
-        self._is_running = False
+        logger.info("Discovery timed out")
+
+        self._discovery_duration = None
+
         if self._connect_timeout_timer:
             self._connect_timeout_timer.cancel()
         if self._controller:
             self._controller.disconnect()
+
+        # The flag needs to be set here because
+        # self._manager.stop() unblocks self._start_onboarding()
+        self._bt_restart_underway = True
         self._manager.stop_discovery()
         self._manager.stop()
 
-    def controller_discovered(self, controller):
+        self.is_running = False
+        if self._nuimo_onboarding_attempts != MAX_ONBOARDING_ATTEMPTS:
+            self._restart_bluetooth()
+
+    def controller_discovered(self, discovered_nuimo):
+        """
+        Callback. _start_discovery resulted in a nuimo.
+
+        Stop the timers and the underlying scanning done
+        by the bt module.
+        Initiate connecting to the discovred nuimo
+        """
+
+        logger.debug("Discovered nuimo: %s" % discovered_nuimo.mac_address)
+        self._discovery_timeout_timer.cancel()
+
         if not self._is_running:
+            logger.debug("self._is_running is false")
             return
         if self._controller is not None:
-            logger.debug("%s discovered but ignored, already connecting to another one", controller.mac_address)
+            logger.debug("%s discovered but ignored, already connecting to another one", discovered_nuimo.mac_address)
             return
-        if self._required_mac_address and (self._required_mac_address.lower() != controller.mac_address.lower()):
-            logger.debug("%s discovered but ignored because we look for a specific one", controller.mac_address)
+        if self._required_mac_address and (self._required_mac_address.lower() != discovered_nuimo.mac_address.lower()):
+            logger.debug("%s discovered but ignored because we look for a specific one", discovered_nuimo.mac_address)
             return
-        logger.debug("%s discovered, stopping discovery and trying to connect", controller.mac_address)
+
+        self._discovery_duration = round(time.time() - self._discovery_duration)
+        logger.debug("Discovery took %ss" % self._discovery_duration)
+
+        logger.debug("Stopping nuimo discovery")
         self._manager.stop_discovery()
-        self._connect_timeout_timer = threading.Timer(20, self.connect_timed_out)
+
+        self.start_connection(discovered_nuimo)
+
+    def start_connection(self, discovered_nuimo):
+        """
+        Blocking. Starts the nuimo discovery.
+
+        Initiates the process of connecting to a nuimo and
+        the threads to enforce timeout.
+
+        On succesfull connect 'connect_succeeded' is called.
+        On failure:
+         * by timeout 'connect_timed_out'
+         * or fail response from the underlying libs - 'connect_failed'
+        """
+
+        self._connect_timeout_timer = threading.Timer(CONNECTION_TIMEOUT, self.connect_timed_out)
+        logger.debug("Starting thread for connection timeout[%s]" % CONNECTION_TIMEOUT)
         self._connect_timeout_timer.start()
-        self._controller = controller
+        self._controller = discovered_nuimo
         self._controller.listener = self
+        logger.debug("Trying to connect to nuimo: %s" % discovered_nuimo.mac_address)
+        self._connect_duration = time.time()
         self._controller.connect()
 
     def connect_succeeded(self):
         if not self._is_running:
             return
         logger.debug("%s successfully connected, stopping now", self._controller.mac_address)
+        self._nuimo_connected = True
         if self._connect_timeout_timer:
             self._connect_timeout_timer.cancel()
+
+            self._connect_duration = round(time.time() - self._connect_duration)
+            logger.debug("Connecting took %ss" % self._connect_duration)
+
         self._manager.stop()
 
     def connect_failed(self, error):
-        if not self._is_running:
-            return
-        logger.info("%s connection failed: %s", self._controller.mac_address, error)
-        self._manager.stop_discovery()
-        self._connect_timeout_timer = threading.Timer(20, self.connect_timed_out)
-        self._connect_timeout_timer.start()
-        self._controller.listener = self
-        self._controller.connect()
+        """
+        Callback. start_connection failed.
+
+        There can be multiple underlying reasons for having
+        the connection fail.
+        https://github.com/getsenic/gatt-python/blob/master/gatt/gatt_linux.py#L297
+
+        For the current solution we're all the reasons as
+        issues that can be sloved by restarting the module.
+        This might change with new insights.
+
+        For that case we're actin as the connection timed
+        out.
+        """
+
+        # This is to identify failing cases different from a timeout.
+        logger.info("%s connection failed (didn't timeout): %s", self._controller.mac_address, error)
+        self.connect_timed_out()
 
     def connect_timed_out(self):
+        """
+        Callback. start_connection timed out.
+
+        Stops all bluetooth related actuivity and
+        initiates BT restart.
+
+        Couldn't find an explicit method that will cancel
+        the blocking connect on a timeout (this method when traced down):
+        https://github.com/getsenic/gatt-python/blob/master/gatt/gatt_linux.py#L282
+        am assuming that ending with self._restart_bluetooth()
+        eliminates the need for it. Do question the approach.
+        """
+
         if not self._is_running:
             return
-        self.connect_failed(Exception("Timeout"))
+
+        logger.info("Connect failed due to timeout")
+
+        # Restoring duration to initial state
+        self._connect_duration = None
+
+        # The flag needs to be set here because
+        # self._manager.stop() unblocks self._start_onboarding()
+        self._bt_restart_underway = True
+        self._manager.stop()
+        self.is_running = False
+
+        if self._nuimo_onboarding_attempts != MAX_ONBOARDING_ATTEMPTS:
+            self._restart_bluetooth()

--- a/senic_hub/backend/nuimo_setup.py
+++ b/senic_hub/backend/nuimo_setup.py
@@ -22,6 +22,12 @@ MAX_ONBOARDING_ATTEMPTS = 3
 class NuimoSetup(nuimo.ControllerManagerListener, nuimo.ControllerListener):  # pragma: no cover
 
     def __init__(self, adapter_name):
+        # A quick way to test how often are issues causes by adapter naming
+        logger.debug("Using adapter (self.ble_adapter_name): %s" % adapter_name)
+        import subprocess
+        output = subprocess.check_output("hciconfig")
+        logger.debug("Adapter (from hciconfig): %s " % str(output.split()[0]))
+
         self._adapter_name = adapter_name
         self._gatt_manager = gatt.DeviceManager(self._adapter_name)
         self._manager = nuimo.ControllerManager(self._adapter_name)
@@ -171,11 +177,10 @@ class NuimoSetup(nuimo.ControllerManagerListener, nuimo.ControllerListener):  # 
         """
         Callback. _start_discovery timed out.
 
-        Stops all bluetooth related actuivity and
+        Stops all bluetooth related activity and
         initiates BT restart.
         """
 
-        # Why is this false?
         if not self._is_running:
             return
         logger.info("Discovery timed out")
@@ -229,7 +234,7 @@ class NuimoSetup(nuimo.ControllerManagerListener, nuimo.ControllerListener):  # 
 
     def start_connection(self, discovered_nuimo):
         """
-        Blocking. Starts the nuimo discovery.
+        Blocking. Starts the nuimo connection.
 
         Initiates the process of connecting to a nuimo and
         the threads to enforce timeout.

--- a/senic_hub/backend/views/config.py
+++ b/senic_hub/backend/views/config.py
@@ -2,7 +2,7 @@ from time import sleep
 
 from cornice.service import Service
 
-from ..commands import create_configuration_files_and_restart_apps
+from ..commands import create_nuimo_app_cfg
 from ..config import path
 from ..supervisor import stop_program
 from .api_descriptions import descriptions as desc
@@ -27,7 +27,7 @@ def post_configuration(request):
     logger.info("Stopping device discovery")
     stop_program('device_discovery')
 
-    create_configuration_files_and_restart_apps(request.registry.settings)
+    create_nuimo_app_cfg(request.registry.settings)
 
     # Wait for Nuimo App to restart and connect to Nuimo
     # TODO: Add D-Bus interface to Nuimo and wait for its ready signal

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         [console_scripts]
         netwatch = senic_hub.backend.netwatch:netwatch_cli
         bluenet = senic_hub.bluenet.bluenet:bluenet_cli
-        create_configurations = senic_hub.backend.commands:create_configuration_files_and_restart_apps
+        create_configurations = senic_hub.backend.commands:create_nuimo_app_cfg
         device_discovery = senic_hub.backend.device_discovery:command
         nuimo_app = senic_hub.nuimo_app.__main__:main
     """,


### PR DESCRIPTION
This addresses https://github.com/getsenic/senic-hub/issues/406

The change history doesn't mean much of it's own so I tried to document and refactor methods 
to give you an overview on what's going on.
Please also check the commit messages (for more clarification).

Given that the issue of (sometimes) not being able to connect to a Nuimo during
onboarding was never traced to a cause, the only thing we can do is to assume
it was fixed by having it not show again (ever) during onboardings.

I onboarded 5+ times without problems, and tried some irregular combinations
(discover Nuimo but can't connect, can't discover, connect normally after previous two)
that didn't end up crashing the app. 

More than a confirmation if this works correctly, I would ask you to take a look if
the code is readable enough and give feedback on that.

I'm continuing on https://github.com/getsenic/senic-hub/issues/407,
based from this branch. Will merge this into nrf52-onboarding-nuimo once the 
review passes (please just review, don't merge it). 